### PR TITLE
fix installation command in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ Required: Go 1.13+.
 
 ```
 $ go get github.com/minamijoyo/tflock
+$ cd $GOPATH/src/github.com/minamijoyo/tflock
+$ go install
 
 $ tflock --version
 0.0.1


### PR DESCRIPTION
In the installation section in README.md, the installation command after checkout was missing.
So I added install command.